### PR TITLE
update on the error serverity

### DIFF
--- a/bin/runLint.js
+++ b/bin/runLint.js
@@ -49,7 +49,7 @@ const processor = remark()
   .use(remarkLintNoHiddenTableCell, ['error'])
   .use(remarkLintNoAngleBrackets.default, ['error'])
   .use(remarkLintCheckFrontmatter.default)
-  .use(remarkLintHtmlCheck.default, ['error']);
+  .use(remarkLintHtmlCheck.default);
 
 if (!fs.existsSync(srcPagesDir)) {
     log('❌ src/pages directory not found', 'error');


### PR DESCRIPTION
Due to realize some repo will use custom components, change the lint rule of checking on the html into warnings only instead of error.  Warning will not stop the build but error will. 