### PR TITLE
Add lint options

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ npx --yes github:AdobeDocs/adp-devsite-utils runLint --dead-links-only
 **Options:**
 - `-v` or `--verbose` - Show detailed output including all files processed
 - `--dead-links-only` - Only check for dead external URLs (skips all other linting rules)
-- `--skip-dead-links` or `--no-dead-links` - Run all linting rules EXCEPT dead links check (faster)
+- `--skip-dead-links` - Run all linting rules EXCEPT dead links check (faster)
 
 **Troubleshooting**: If pages are not showing up as expected, check lint errors or warnings to identify potential issues.
 

--- a/README.md
+++ b/README.md
@@ -62,6 +62,30 @@ Once all three servers are running, navigate to `http://localhost:3000/<pathPref
 
 Validates markdown syntax, links, content structure, and Adobe style guidelines.
 
+### Running from Another Repo
+
+You can run the linter from any other repo using npx:
+
+```bash
+# Run all linting rules (errors and summary only)
+npx --yes github:AdobeDocs/adp-devsite-utils runLint
+
+# Run with verbose output (shows all files processed and details)
+npx --yes github:AdobeDocs/adp-devsite-utils runLint -v
+
+# Run all linting rules EXCEPT dead links (faster)
+npx --yes github:AdobeDocs/adp-devsite-utils runLint --skip-dead-links
+
+# Check only for dead external links
+npx --yes github:AdobeDocs/adp-devsite-utils runLint --dead-links-only
+
+```
+
+**Options:**
+- `-v` or `--verbose` - Show detailed output including all files processed
+- `--dead-links-only` - Only check for dead external URLs (skips all other linting rules)
+- `--skip-dead-links` or `--no-dead-links` - Run all linting rules EXCEPT dead links check (faster)
+
 **Troubleshooting**: If pages are not showing up as expected, check lint errors or warnings to identify potential issues.
 
 ## Navigation

--- a/bin/runLint.js
+++ b/bin/runLint.js
@@ -54,17 +54,8 @@ if (deadLinksOnly) {
   processor = processor
     .use(remarkLintNoDeadUrls, {
         deadOrAliveOptions: {
-            //maxRetries: 0, // Disable retries
-            //sleep: 0, // Disable sleep
-            retry: {
-                limit: 2, // Retry failed requests
-            },
-            timeout: {
-                request: 15000, // Increase timeout to 15 seconds
-            },
-            headers: {
-                'user-agent': 'Mozilla/5.0 (compatible; LinkChecker/1.0)', // Add user agent
-            },
+            maxRetries: 0, // Disable retries
+            sleep: 0, // Disable sleep
             https: {
                 rejectUnauthorized: false, // Don't fail on SSL cert issues
             },
@@ -94,17 +85,8 @@ if (deadLinksOnly) {
     processor = processor
       .use(remarkLintNoDeadUrls, {
           deadOrAliveOptions: {
-              //maxRetries: 0, // Disable retries
-              //sleep: 0, // Disable sleep
-              retry: {
-                  limit: 2, // Retry failed requests
-              },
-              timeout: {
-                  request: 15000, // Increase timeout to 15 seconds
-              },
-              headers: {
-                  'user-agent': 'Mozilla/5.0 (compatible; LinkChecker/1.0)', // Add user agent
-              },
+              maxRetries: 0, // Disable retries
+              sleep: 0, // Disable sleep
               https: {
                   rejectUnauthorized: false, // Don't fail on SSL cert issues
               },

--- a/bin/runLint.js
+++ b/bin/runLint.js
@@ -95,7 +95,7 @@ if (markdownFiles.length === 0) {
     process.exit(0);
 }
 
-log(`Found ${markdownFiles.length} markdown files to test`);
+verbose(`Found ${markdownFiles.length} markdown files to test`);
 
 // Process each file
 let totalIssues = 0;

--- a/bin/runLint.js
+++ b/bin/runLint.js
@@ -54,10 +54,19 @@ if (deadLinksOnly) {
   processor = processor
     .use(remarkLintNoDeadUrls, {
         deadOrAliveOptions: {
-            maxRetries: 0, // Disable retries
-            sleep: 0, // Disable sleep
+            //maxRetries: 0, // Disable retries
+            //sleep: 0, // Disable sleep
+            retry: {
+                limit: 2, // Retry failed requests
+            },
             timeout: {
-                request: 10000, // Set a 10-second timeout
+                request: 15000, // Increase timeout to 15 seconds
+            },
+            headers: {
+                'user-agent': 'Mozilla/5.0 (compatible; LinkChecker/1.0)', // Add user agent
+            },
+            https: {
+                rejectUnauthorized: false, // Don't fail on SSL cert issues
             },
             followRedirect: true, // Allow redirects (don't treat as dead links)
         },
@@ -79,16 +88,25 @@ if (deadLinksOnly) {
     .use(remarkLintSelfCloseComponent.default, ['error'])
     .use(remarkLintNoHtmlTag.default)
     .use(remarkLintNoCodeTable.default);
-  
+
   // Add dead links check unless explicitly skipped
   if (!skipDeadLinks) {
     processor = processor
       .use(remarkLintNoDeadUrls, {
           deadOrAliveOptions: {
-              maxRetries: 0, // Disable retries
-              sleep: 0, // Disable sleep
+              //maxRetries: 0, // Disable retries
+              //sleep: 0, // Disable sleep
+              retry: {
+                  limit: 2, // Retry failed requests
+              },
               timeout: {
-                  request: 10000, // Set a 10-second timeout
+                  request: 15000, // Increase timeout to 15 seconds
+              },
+              headers: {
+                  'user-agent': 'Mozilla/5.0 (compatible; LinkChecker/1.0)', // Add user agent
+              },
+              https: {
+                  rejectUnauthorized: false, // Don't fail on SSL cert issues
               },
               followRedirect: true, // Allow redirects (don't treat as dead links)
           },

--- a/bin/runLint.js
+++ b/bin/runLint.js
@@ -49,6 +49,7 @@ const processor = remark()
           timeout: {
               request: 10000, // Set a 10-second timeout
           },
+          followRedirect: true, // Allow redirects (don't treat as dead links)
       },
   })
   .use(remarkLintNoMultipleToplevelHeadings)

--- a/bin/runLint.js
+++ b/bin/runLint.js
@@ -23,7 +23,7 @@ const targetDir = process.cwd();
 
 // Check for flags
 const deadLinksOnly = process.argv.includes('--dead-links-only');
-const skipDeadLinks = process.argv.includes('--skip-dead-links') || process.argv.includes('--no-dead-links');
+const skipDeadLinks = process.argv.includes('--skip-dead-links');
 
 logSection('TEST LINT');
 if (deadLinksOnly) {

--- a/linters/remark-lint-check-frontmatter.js
+++ b/linters/remark-lint-check-frontmatter.js
@@ -186,6 +186,7 @@ const remarkLintCheckFrontmatter = (severity = 'warning') => {
         'remark-lint:check-frontmatter'
       )
     }
+  }
 }
 
 export default remarkLintCheckFrontmatter

--- a/linters/remark-lint-check-frontmatter.js
+++ b/linters/remark-lint-check-frontmatter.js
@@ -93,8 +93,6 @@ const remarkLintCheckFrontmatter = (severity = 'warning') => {
             'remark-lint:check-frontmatter'
           )
         }
-      } else {
-        console.log(`  ✅ Found title: "${title}"`)
       }
 
       // Check if description exists and is not empty
@@ -123,8 +121,6 @@ const remarkLintCheckFrontmatter = (severity = 'warning') => {
             'remark-lint:check-frontmatter'
           )
         }
-      } else {
-        console.log(`  ✅ Found description: "${description}"`)
       }
 
       // Additional validation: check title length
@@ -190,9 +186,6 @@ const remarkLintCheckFrontmatter = (severity = 'warning') => {
         'remark-lint:check-frontmatter'
       )
     }
-
-    console.log('✅ Frontmatter validation complete!')
-  }
 }
 
 export default remarkLintCheckFrontmatter


### PR DESCRIPTION
Adding running lint deadlinks options.

Testing in cc-everywhere repo where we can have all these options now 
"lint": "npx --yes github:AdobeDocs/adp-devsite-utils#add-lint-options runLint -v",
"lint:showErrorOnly": "npx --yes github:AdobeDocs/adp-devsite-utils#add-lint-options runLint",
"lint:deadlinksonly": "npx --yes github:AdobeDocs/adp-devsite-utils#add-lint-options runLint --dead-links-only -v",
    "lint:skipdeadlinks": "npx --yes github:AdobeDocs/adp-devsite-utils#add-lint-options runLint --skip-dead-links -v"