### PR TITLE
adding new html tags to skip lint error

### DIFF
--- a/linters/remark-lint-no-html-tags.js
+++ b/linters/remark-lint-no-html-tags.js
@@ -11,7 +11,7 @@ const remarkLintNoHtmlTags = (severity = 'warning') => {
       'discoverblock', 'announcement', 'carousel', 'summary',
       'infocard', 'embed', 'redoclyapiblock', 'codeblock',
       'list', 'horizontalline', 'tab', 'columns', 'details',
-      'hero', 'title', 'superhero', 'edition'
+      'hero', 'title', 'superhero', 'edition', 'fragment', 'accordionitem', 'accordion'
     ]
 
     // Visit all HTML nodes to find unauthorized HTML tags


### PR DESCRIPTION
Adding tags to make sure it doesn't error out. 

<img width="1163" height="140" alt="Screenshot 2026-01-05 at 10 17 20 AM" src="https://github.com/user-attachments/assets/94e052eb-d811-4a05-8efc-c3dbc6fe9aa0" />

Now: 

<img width="1037" height="136" alt="Screenshot 2026-01-05 at 10 17 31 AM" src="https://github.com/user-attachments/assets/a6c4fbe2-4cfa-44fb-a12a-f322574c32bb" />
