### PR TITLE
fix linter check for table

### DIFF
--- a/linters/remark-lint-no-code-in-table.js
+++ b/linters/remark-lint-no-code-in-table.js
@@ -9,37 +9,27 @@ const remarkLintNoCodeTables = (severity = 'warning') => {
     const content = file.toString()
     const lines = content.split('\n')
 
-    let inCodeBlock = false
+    let inTable = false
 
     for (let lineNumber = 0; lineNumber < lines.length; lineNumber++) {
       const line = lines[lineNumber]
       const trimmedLine = line.trim()
 
-      // Track code fence blocks (```)
-      if (trimmedLine.startsWith('```')) {
-        inCodeBlock = !inCodeBlock
-        continue
-      }
-
-      // Skip lines inside code blocks
-      if (inCodeBlock) {
-        continue
-      }
-
-      // Only check lines that are table rows (contain |)
+      // Check if this line is part of a table (contains |)
       const pipeCount = (trimmedLine.match(/\|/g) || []).length
-      if (pipeCount >= 1 && (trimmedLine.includes('{') || trimmedLine.includes('}'))) {
-        // Remove content within backticks before checking
-        const lineWithoutInlineCode = trimmedLine.replace(/`[^`]*`/g, '')
-
-        // Only flag if { or } still exists after removing inline code
-        if (lineWithoutInlineCode.includes('{') || lineWithoutInlineCode.includes('}')) {
+      
+      if (pipeCount >= 1) {
+        // We're in a table
+        inTable = true
+        
+        // Check if this table row contains triple backticks
+        if (trimmedLine.includes('```')) {
           const position = {
             start: { line: lineNumber + 1, column: 1 },
             end: { line: lineNumber + 1, column: line.length }
           }
 
-          const message = 'JSON-like content detected in table row. Consider moving code examples outside the table.'
+          const message = 'Multi-line code blocks (```) are not allowed in tables. Use inline code with single backticks (`) instead, or move the code block outside the table.'
 
           if (actualSeverity === 'error') {
             file.fail(message, position, 'remark-lint:no-code-blocks-in-tables')
@@ -47,6 +37,9 @@ const remarkLintNoCodeTables = (severity = 'warning') => {
             file.message(message, position, 'remark-lint:no-code-blocks-in-tables')
           }
         }
+      } else if (trimmedLine === '') {
+        // Empty line ends the table
+        inTable = false
       }
     }
   }


### PR DESCRIPTION
This will make the linter only check against any multiple line of code and do not check against {} as the {} has already been check in the no-unescaped-opening-curly-bracket linter rule.