### PR TITLE
added linter: Enforce Explicit Filenames

### DIFF
--- a/linters/remark-lint-internal-link-extension.js
+++ b/linters/remark-lint-internal-link-extension.js
@@ -33,8 +33,11 @@ const remarkLintInternalLinkExtension = (severity = 'warning') => {
 
       if (!urlPath.endsWith('.md')) {
         const position = node.position
+        const cleanPath = urlPath.replace(/\/$/, '')
 
-        const message = `Internal link "${url}" must end with .md. Run "npm run normalizeLinks" to fix automatically, or manually change to "${urlPath.replace(/\/$/, '')}/index.md${url.includes('#') ? '#' + url.split('#')[1] : ''}" or "${urlPath.replace(/\/$/, '')}.md${url.includes('#') ? '#' + url.split('#')[1] : ''}".`
+        const message = urlPath.endsWith('/')
+          ? `Relative link "${url}" ends with a trailing slash. Links must include the filename (e.g., index.md). Run "npm run normalizeLinks" to fix automatically, or manually change to "${cleanPath}/index.md" or "${cleanPath}.md".`
+          : `Internal link "${url}" must end with .md. Run "npm run normalizeLinks" to fix automatically, or manually change to "${cleanPath}/index.md" or "${cleanPath}.md".`
 
         if (actualSeverity === 'error') {
           file.fail(message, position, 'remark-lint:internal-link-extension')


### PR DESCRIPTION
Test File:https://github.com/AdobeDocs/adp-devsite-github-actions-test/blob/main/src/pages/test/trailing-slash.md

[DEVSITE-2153](https://jira.corp.adobe.com/browse/DEVSITE-2153)
<img width="1778" height="172" alt="image" src="https://github.com/user-attachments/assets/38970319-8601-4cd6-8044-deb5a38481c8" />
