### PR TITLE
adding include internal links

### DIFF
--- a/bin/runLint.js
+++ b/bin/runLint.js
@@ -36,12 +36,12 @@ if (fs.existsSync(packageJsonPath)) {
         const packageJson = JSON.parse(fs.readFileSync(packageJsonPath, 'utf8'));
         skipUrlPatterns = packageJson?.lint?.skipUrlPatterns || [];
         skipFrontmatterPaths = packageJson?.lint?.skipFrontmatterPaths || [];
-        
+
         if (skipUrlPatterns.length > 0) {
             logStep(`Skipping ${skipUrlPatterns.length} URL pattern(s):`);
             skipUrlPatterns.forEach(pattern => verbose(`  - ${pattern}`));
         }
-        
+
         if (skipFrontmatterPaths.length > 0) {
             logStep(`Skipping frontmatter check for ${skipFrontmatterPaths.length} path(s):`);
             skipFrontmatterPaths.forEach(pattern => verbose(`  - ${pattern}`));
@@ -57,18 +57,22 @@ function shouldSkipFrontmatter(filePath) {
     return skipFrontmatterPaths.some(pattern => relativePath.startsWith(pattern));
 }
 
-// Check for flags
-const deadLinksOnly = process.argv.includes('--dead-links-only');
+// Check for flags (support both new and deprecated names)
+const externalLinksOnly = process.argv.includes('--external-links-only') || process.argv.includes('--dead-links-only');
+const internalLinksOnly = process.argv.includes('--internal-links-only');
 const skipDeadLinks = process.argv.includes('--skip-dead-links');
-const includeInternalLinks = process.argv.includes('--include-internal');
+const linksOnlyMode = externalLinksOnly || internalLinksOnly;
 
 logSection('TEST LINT');
 
 // Determine lint mode for report
 let lintMode = 'Full Linting (all rules + dead links check)';
-if (deadLinksOnly) {
-    logStep(includeInternalLinks ? 'Testing dead links (external + internal)' : 'Testing dead links only');
-    lintMode = includeInternalLinks ? 'Dead Links Only (external + internal)' : 'Dead Links Only';
+if (linksOnlyMode) {
+    const modes = [];
+    if (externalLinksOnly) modes.push('external');
+    if (internalLinksOnly) modes.push('internal');
+    logStep(`Testing dead links (${modes.join(' + ')})`);
+    lintMode = `Dead Links Only (${modes.join(' + ')})`;
 } else if (skipDeadLinks) {
     logStep('Testing remark rules (skipping dead links check)');
     lintMode = 'Remark Rules Only (dead links skipped)';
@@ -111,28 +115,30 @@ const srcPagesDir = path.join(targetDir, 'src', 'pages');
 function createProcessor(includeFrontmatterCheck) {
   let processors = remark().use(remarkFrontmatter, ['yaml']);
 
-  if (deadLinksOnly) {
-    // Check internal links (local filesystem) when --include-internal is set
-    if (includeInternalLinks) {
+  if (linksOnlyMode) {
+    // Check internal links (local filesystem) when --internal-links-only is set
+    if (internalLinksOnly) {
       processors = processors
         .use(remarkValidateLinks, {
           skipPathPatterns: [/.*config\.md.*/],
           root: srcPagesDir
         });
     }
-    // Check external dead URLs (HTTP)
-    processors = processors
-      .use(remarkLintNoDeadUrls, {
+    // Check external dead URLs (HTTP) when --external-links-only is set
+    if (externalLinksOnly) {
+      processors = processors
+        .use(remarkLintNoDeadUrls, {
           skipUrlPatterns,
           deadOrAliveOptions: {
-              maxRetries: 0, // Disable retries
-              sleep: 0, // Disable sleep
-              https: {
-                  rejectUnauthorized: false, // Don't fail on SSL cert issues
-              },
-              followRedirect: true, // Allow redirects (don't treat as dead links)
+            maxRetries: 0, // Disable retries
+            sleep: 0, // Disable sleep
+            https: {
+              rejectUnauthorized: false, // Don't fail on SSL cert issues
+            },
+            followRedirect: true, // Allow redirects (don't treat as dead links)
           },
-      });
+        });
+    }
   } else {
     // Run all linting rules (optionally skipping dead links)
     processors = processors
@@ -147,12 +153,12 @@ function createProcessor(includeFrontmatterCheck) {
       .use(remarkLintNoHtmlComments.default, ['error'])
       .use(remarkLintNoBrInTables.default, ['error'])
       .use(remarkLintNoBlockInList.default, ['error']);
-    
+
     // Only add frontmatter check if not skipping
     if (includeFrontmatterCheck) {
       processors = processors.use(remarkLintCheckFrontmatter.default);
     }
-    
+
     processors = processors
       .use(remarkLintSelfCloseComponent.default, ['error'])
       .use(remarkLintNoHtmlTag.default, ['error'])
@@ -179,7 +185,7 @@ function createProcessor(includeFrontmatterCheck) {
         });
     }
   }
-  
+
   return processors;
 }
 
@@ -240,7 +246,7 @@ for (const filePath of markdownFiles) {
         // Choose the appropriate processor based on whether frontmatter check should be skipped
         const skipFrontmatter = shouldSkipFrontmatter(filePath);
         const processor = skipFrontmatter ? processorWithoutFrontmatter : processorWithFrontmatter;
-        
+
         if (skipFrontmatter) {
             verbose(`Processing (skip frontmatter): ${relativePath}`);
         } else {
@@ -254,7 +260,7 @@ for (const filePath of markdownFiles) {
             filesWithIssues++;
             totalIssues += result.messages.length;
             verbose(`\n${relativePath}:`);
-            
+
             // Add file header to report
             addToReport('───────────────────────────────────────────────────────────────');
             addToReport(`📄 FILE: ${relativePath}`);
@@ -264,7 +270,7 @@ for (const filePath of markdownFiles) {
             result.messages.forEach(message => {
                 const severity = message.fatal ? '❌ ERROR' : '⚠️  WARNING';
                 verbose(` ${severity} ${message}`);
-                
+
                 // Track error/warning counts
                 if (message.fatal) {
                     hasFatalErrors = true;
@@ -293,7 +299,7 @@ for (const filePath of markdownFiles) {
         totalIssues++;
         totalErrors++;
         hasFatalErrors = true;
-        
+
         // Add processing error to report
         const relativePath = path.relative(targetDir, filePath);
         addToReport('───────────────────────────────────────────────────────────────');

--- a/bin/runLint.js
+++ b/bin/runLint.js
@@ -60,14 +60,15 @@ function shouldSkipFrontmatter(filePath) {
 // Check for flags
 const deadLinksOnly = process.argv.includes('--dead-links-only');
 const skipDeadLinks = process.argv.includes('--skip-dead-links');
+const includeInternalLinks = process.argv.includes('--include-internal');
 
 logSection('TEST LINT');
 
 // Determine lint mode for report
 let lintMode = 'Full Linting (all rules + dead links check)';
 if (deadLinksOnly) {
-    logStep('Testing dead links only');
-    lintMode = 'Dead Links Only';
+    logStep(includeInternalLinks ? 'Testing dead links (external + internal)' : 'Testing dead links only');
+    lintMode = includeInternalLinks ? 'Dead Links Only (external + internal)' : 'Dead Links Only';
 } else if (skipDeadLinks) {
     logStep('Testing remark rules (skipping dead links check)');
     lintMode = 'Remark Rules Only (dead links skipped)';
@@ -111,7 +112,15 @@ function createProcessor(includeFrontmatterCheck) {
   let processors = remark().use(remarkFrontmatter, ['yaml']);
 
   if (deadLinksOnly) {
-    // Only check for dead URLs
+    // Check internal links (local filesystem) when --include-internal is set
+    if (includeInternalLinks) {
+      processors = processors
+        .use(remarkValidateLinks, {
+          skipPathPatterns: [/.*config\.md.*/],
+          root: srcPagesDir
+        });
+    }
+    // Check external dead URLs (HTTP)
     processors = processors
       .use(remarkLintNoDeadUrls, {
           skipUrlPatterns,


### PR DESCRIPTION
For the check on the deadlinksonly, we added the option to include internal links as well.  This will make the user easer to find what internal and external links are returning a 404.