### PR TITLE
update header to first level

### DIFF
--- a/bin/buildNavigation.js
+++ b/bin/buildNavigation.js
@@ -134,7 +134,9 @@ function buildSideNavRecursively(sideNav, depth, verbose) {
     let sideNavMarkdown = '';
 
     for (var k in sideNav) {
-        let header = sideNav[k].header ? ' header' : '';
+        // Only add header at top-level of subpages (depth 1); nested items render as links
+        let isTopLevel = depth === 1;
+        let header = (sideNav[k].header && isTopLevel) ? ' header' : '';
         let resolvedPath = resolvePathToMarkdown(sideNav[k].path, verbose);
         sideNavMarkdown += header ? `${insertSpace(depth)}- ${sideNav[k].title}${header}\n` : `${insertSpace(depth)}- [${sideNav[k].title}](${resolvedPath})\n`;
         verbose(`    Side nav item: ${sideNav[k].title} (depth ${depth}) -> ${resolvedPath}`);


### PR DESCRIPTION
based on this file https://jira.corp.adobe.com/browse/DEVSITE-2166 the Customer accounts will be header.  This is caused by the code is recusing in all the header in subPages.  However based on aio-theme readme, it should only pick up the header:true on the first level in subPages. 
Before:
<img width="1193" height="998" alt="config_bug" src="https://github.com/user-attachments/assets/832a4a8d-ddef-4bdf-a212-cd6b8d0e72e0" />

After:
<img width="777" height="728" alt="Screenshot 2026-03-13 at 10 41 36 AM" src="https://github.com/user-attachments/assets/4dc7271b-b6a9-4cb5-becc-d69852386ce0" />

