### PR TITLE
rename asset files as well

### DIFF
--- a/bin/renameFiles.js
+++ b/bin/renameFiles.js
@@ -9,7 +9,7 @@ const {
     readRedirectionsFile,
     writeRedirectionsFile,
     getRedirectionsFilePath,
-    getDeployableFiles,
+    getFilesForRename,
     getMarkdownFiles,
     getFindPatternForMarkdownFiles,
     getReplacePatternForMarkdownFiles,
@@ -279,9 +279,9 @@ try {
         verbose(`Cleaned up ${dirsRemoved} directories`);
     }
 
-        logStep('Getting deployable files');
-    const files = getDeployableFiles(__dirname);
-    verbose(`Found ${files.length} deployable files`);
+        logStep('Getting files to rename');
+    const files = getFilesForRename(__dirname);
+    verbose(`Found ${files.length} files (deployable + assets)`);
 
     logStep('Creating file map');
     const fileMap = getFileMap(files);

--- a/bin/scriptUtils.js
+++ b/bin/scriptUtils.js
@@ -122,6 +122,18 @@ function getDeployableFiles(__dirname) {
     return getFiles(['.md', '.json'], __dirname);
 }
 
+/**
+ * All files under src/pages that should be renamed (deployable + assets).
+ * Includes images so directories containing only assets get renamed too,
+ * avoiding duplicate underscore vs hyphen directories.
+ */
+function getFilesForRename(__dirname) {
+    return getFiles(
+        ['.md', '.json', '.png', '.jpg', '.jpeg', '.gif', '.svg', '.webp', '.pdf', '.ico'],
+        __dirname
+    );
+}
+
 function getMarkdownFiles(__dirname) {
     return getFiles(['.md'], __dirname);
 }
@@ -158,6 +170,7 @@ export {
     readRedirectionsFile,
     writeRedirectionsFile,
     getDeployableFiles,
+    getFilesForRename,
     getMarkdownFiles,
     getFindPatternForMarkdownFiles,
     getReplacePatternForMarkdownFiles,


### PR DESCRIPTION
This is to fix the issue with renaming only take places for .md files and not all the asset files like image files.  

After running this from express-add-ons-doc from an old branch, the renameFiles work properly now. 

<img width="610" height="705" alt="Screenshot 2026-03-13 at 4 08 09 PM" src="https://github.com/user-attachments/assets/1e99d1fe-9b13-4f6a-99b2-3865b6c68952" />

Assets also get coverted over under getting-started instead of leaving behind in getting_started.
<img width="490" height="900" alt="Screenshot 2026-03-16 at 1 12 58 PM" src="https://github.com/user-attachments/assets/4c0fc533-32e6-4366-86f7-9e170942d3dd" />


And the links look like it's been fixed automatically as well. 

<img width="1480" height="728" alt="Screenshot 2026-03-13 at 4 16 09 PM" src="https://github.com/user-attachments/assets/7b2b663d-b1a6-4ddf-9550-d1b6af2047b9" />
