### PR TITLE
fix: lintNoJsonInSrcPages is not a function

### DIFF
--- a/bin/runLint.js
+++ b/bin/runLint.js
@@ -244,7 +244,7 @@ let totalErrors = 0;
 let totalWarnings = 0;
 
 // Pre-check: detect JSON files in src/pages/
-const jsonCheckResult = lintNoJsonInSrcPages(srcPagesDir, targetDir);
+const jsonCheckResult = lintNoJsonInSrcPages.default(srcPagesDir, targetDir);
 if (jsonCheckResult.messages.length > 0) {
     addToReport('───────────────────────────────────────────────────────────────');
     addToReport('📁 JSON FILES IN src/pages/');


### PR DESCRIPTION
## Description
Fixes `TypeError: lintNoJsonInSrcPages is not a function` thrown during CI lint runs. `lintNoJsonInSrcPages` is a dynamic import, so the exported function must be accessed via `.default`.

Issue reported in support channel: https://adobeio.slack.com/archives/C01GU3V8XE0/p1774340111745139

## Before
<img width="1564" height="1045" alt="Screenshot 2026-03-24 at 7 05 42 AM" src="https://github.com/user-attachments/assets/39ac7097-d54c-4baa-869c-11beb55bd146" />

## After
<img width="1565" height="1046" alt="Screenshot 2026-03-24 at 7 11 53 AM" src="https://github.com/user-attachments/assets/18adfb28-7d55-4a31-9c69-d9481e3fbd4b" />

## Test
https://github.com/AdobeDocs/adp-devsite-github-actions-test/pull/122

