### PR TITLE
Devsite 2159 rename

### DIFF
--- a/bin/renameFiles.js
+++ b/bin/renameFiles.js
@@ -34,14 +34,14 @@ try {
         const isScreamingSnakeCase = new RegExp(/^[A-Z0-9_]*$/).test(str);
         str = isScreamingSnakeCase ? str.toLowerCase() : str;
         return str
-            .match(/[A-Z]{2,}(?=[A-Z][a-z]+[0-9]*|\b)|[A-Z]?[a-z]+[0-9]*|[A-Z]|[0-9]+/g)
+            .match(/[A-Z]{2,}(?=[A-Z][a-z]+[0-9]*|\b)|[A-Z]?[a-z]+[0-9]*|[A-Z]|[0-9]+[a-z]*/g)
             .map((x) => x.toLowerCase())
             .join('-');
     }
 
     function toEdsCase(str) {
-        const isValid = /^([a-z0-9-]*)$/.test(str);
-        return isValid ? str : str.toLowerCase().replace(/_/g, '-');
+        const isValid = Boolean(/^([a-z0-9-]*)$/.test(str));
+        return isValid ? str : toKebabCase(str);
     }
 
     function toUrl(str) {

--- a/bin/renameFiles.js
+++ b/bin/renameFiles.js
@@ -40,8 +40,8 @@ try {
     }
 
     function toEdsCase(str) {
-        const isValid = Boolean(/^([a-z0-9-]*)$/.test(str));
-        return isValid ? str : toKebabCase(str);
+        const isValid = /^([a-z0-9-]*)$/.test(str);
+        return isValid ? str : str.toLowerCase().replace(/_/g, '-');
     }
 
     function toUrl(str) {


### PR DESCRIPTION
https://jira.corp.adobe.com/browse/DEVSITE-2159
The problem is we're adding an extra dash after the number. 

Input | Current | With fix
-- | -- | --
3yc_management | 3-yc-management | 3yc-management
Version2Update | version2-update | version2-update
myFileName | my-file-name | my-file-name
SCREAMING_CASE | screaming-case | screaming-case

This is the tested scenarios.
Fixed:
<img width="1384" height="126" alt="Screenshot 2026-03-25 at 10 08 17 AM" src="https://github.com/user-attachments/assets/049b8871-771f-4580-b1d2-57ed640a9e90" />



