### PR TITLE
DEVSITE-2308 fixed regex for details

### DIFF
--- a/linters/remark-lint-no-details-html.js
+++ b/linters/remark-lint-no-details-html.js
@@ -19,7 +19,7 @@ const remarkLintNoDetailsHtml = (severity = 'warning') => {
 
       if (inCodeBlock) continue
 
-      const detailsOpenRegex = /<details(?:\s[^>]*)?\s*>/gi
+      const detailsOpenRegex = /<details(\s(?:[^>"']*(?:"[^"]*"|'[^']*'))*[^>"']*)?\s*>/gi
       let match
 
       while ((match = detailsOpenRegex.exec(line)) !== null) {


### PR DESCRIPTION
JIRA: [DEVSITE-2308](https://jira.corp.adobe.com/browse/DEVSITE-2308)
Test example: [adobe-io-events](https://github.com/AdobeDocs/adobe-io-events/blob/main/src/pages/guides/using/asset-events/asset-events-properties.md?plain=1#L257)

they are using a subText which contains the angle brackets, that caused a unmatched  > with />, and failed the self-closing check. Linter thinks it's a illegal use of angle bracket but not illegal use of Detail tag. Fixed on this PR allowing the angle brackets in content