### PR TITLE
fix: support delta builds when running in deploy context

### DIFF
--- a/bin/buildContributors.js
+++ b/bin/buildContributors.js
@@ -79,8 +79,8 @@ function getCurrentBranch() {
 
 function getBaseBranch() {
   // for github actions
-  if (process.env.GITHUB_BASE_REF) {
-    return `origin/${process.env.GITHUB_BASE_REF}`;
+  if (process.env.BASE_SHA) {
+    return process.env.BASE_SHA;
   }
 
   // for local development


### PR DESCRIPTION
## Ticket
https://jira.corp.adobe.com/browse/DEVSITE-2292

## Description
Accompanies https://github.com/AdobeDocs/adp-devsite-workflow/pull/23.

Uses `BASE_SHA` in `buildContributors.js` for delta builds in the deploy context.

