### PR TITLE
Devsite 2293

### DIFF
--- a/bin/runLint.js
+++ b/bin/runLint.js
@@ -53,8 +53,16 @@ if (fs.existsSync(packageJsonPath)) {
         skipUrlPatterns = packageJson?.lint?.skipUrlPatterns || [];
         skipFrontmatterPaths = packageJson?.lint?.skipFrontmatterPaths || [];
 
-        // Merge skipRules from package.json with CLI
-        const packageSkipRules = packageJson?.lint?.skipRules || [];
+        // Merge skipRules from package.json (supports both object and array format)
+        const rawSkipRules = packageJson?.lint?.skipRules;
+        let packageSkipRules = [];
+        if (Array.isArray(rawSkipRules)) {
+            packageSkipRules = rawSkipRules;
+        } else if (rawSkipRules && typeof rawSkipRules === 'object') {
+            packageSkipRules = Object.entries(rawSkipRules)
+                .filter(([, enabled]) => enabled === true)
+                .map(([rule]) => rule);
+        }
         skipRules = [...new Set([...skipRules, ...packageSkipRules])];
 
         if (skipUrlPatterns.length > 0) {

--- a/bin/runLint.js
+++ b/bin/runLint.js
@@ -27,43 +27,17 @@ const adpDevsiteUtilsDir = path.dirname(__dirname);
 // Get the current working directory (target repo where the command is run)
 const targetDir = process.cwd();
 
-// Collect rules to skip from SKIP_* environment variables (e.g. SKIP_NO_HTML_COMMENTS=true → no-html-comments)
-let skipRules = [];
-for (const [key, value] of Object.entries(process.env)) {
-    if (key.startsWith('SKIP_') && value === 'true') {
-        const ruleName = key.slice('SKIP_'.length).toLowerCase().replace(/_/g, '-');
-        skipRules.push(ruleName);
-    }
-}
-
-// Also support --skip-rules CLI flag (comma-separated rule names)
-const skipRulesArgIndex = process.argv.indexOf('--skip-rules');
-if (skipRulesArgIndex !== -1 && process.argv[skipRulesArgIndex + 1]) {
-    const cliRules = process.argv[skipRulesArgIndex + 1].split(',').map(r => r.trim()).filter(Boolean);
-    skipRules.push(...cliRules);
-}
-
 // Read lint configuration from content repo's package.json
 let skipUrlPatterns = [];
 let skipFrontmatterPaths = [];
+let skipRulesConfig = {};  // { ruleName: { paths: ["src/pages/..."] } }
 const packageJsonPath = path.join(targetDir, 'package.json');
 if (fs.existsSync(packageJsonPath)) {
     try {
         const packageJson = JSON.parse(fs.readFileSync(packageJsonPath, 'utf8'));
         skipUrlPatterns = packageJson?.lint?.skipUrlPatterns || [];
         skipFrontmatterPaths = packageJson?.lint?.skipFrontmatterPaths || [];
-
-        // Merge skipRules from package.json (supports both object and array format)
-        const rawSkipRules = packageJson?.lint?.skipRules;
-        let packageSkipRules = [];
-        if (Array.isArray(rawSkipRules)) {
-            packageSkipRules = rawSkipRules;
-        } else if (rawSkipRules && typeof rawSkipRules === 'object') {
-            packageSkipRules = Object.entries(rawSkipRules)
-                .filter(([, enabled]) => enabled === true)
-                .map(([rule]) => rule);
-        }
-        skipRules = [...new Set([...skipRules, ...packageSkipRules])];
+        skipRulesConfig = packageJson?.lint?.skipRules || {};
 
         if (skipUrlPatterns.length > 0) {
             logStep(`Skipping ${skipUrlPatterns.length} URL pattern(s):`);
@@ -74,23 +48,35 @@ if (fs.existsSync(packageJsonPath)) {
             logStep(`Skipping frontmatter check for ${skipFrontmatterPaths.length} path(s):`);
             skipFrontmatterPaths.forEach(pattern => verbose(`  - ${pattern}`));
         }
+
+        const skipRuleNames = Object.keys(skipRulesConfig);
+        if (skipRuleNames.length > 0) {
+            logStep(`Configured ${skipRuleNames.length} rule skip(s):`);
+            skipRuleNames.forEach(rule => {
+                const paths = skipRulesConfig[rule].paths || [];
+                verbose(`  - ${rule} → ${paths.length ? paths.join(', ') : '(all files)'}`);
+            });
+        }
     } catch (error) {
         log(`Failed to parse package.json: ${error.message}`, 'warn');
     }
 }
 
-if (skipRules.length > 0) {
-    logStep(`Skipping ${skipRules.length} rule(s):`);
-    skipRules.forEach(rule => verbose(`  - ${rule}`));
-}
-
-// Check whether a ruleId should be skipped.
-// Matches both short form ("no-html-comments") and namespaced form ("remark-lint:no-html-comments").
-function isRuleSkipped(ruleId) {
-    if (!ruleId || skipRules.length === 0) return false;
-    return skipRules.some(skipRule =>
-        ruleId === skipRule || ruleId === `remark-lint:${skipRule}` || ruleId.endsWith(`:${skipRule}`)
-    );
+// Check whether a ruleId should be skipped for a given file.
+// Each entry in skipRulesConfig has a "paths" array of prefix strings.
+// If paths is empty/missing, the rule is skipped globally.
+function isRuleSkipped(ruleId, filePath) {
+    if (!ruleId || Object.keys(skipRulesConfig).length === 0) return false;
+    const relativePath = path.relative(targetDir, filePath);
+    for (const [rule, config] of Object.entries(skipRulesConfig)) {
+        const matches = ruleId === rule
+            || ruleId === `remark-lint:${rule}`
+            || ruleId.endsWith(`:${rule}`);
+        if (!matches) continue;
+        const paths = config.paths || [];
+        if (paths.length === 0 || paths.some(p => relativePath.startsWith(p))) return true;
+    }
+    return false;
 }
 
 // Helper function to check if a file should skip frontmatter check
@@ -130,8 +116,13 @@ addToReport('');
 addToReport(`Generated: ${new Date().toISOString()}`);
 addToReport(`Mode: ${lintMode}`);
 addToReport(`Target Directory: ${targetDir}`);
-if (skipRules.length > 0) {
-    addToReport(`Skipped Rules: ${skipRules.join(', ')}`);
+const reportSkipRuleNames = Object.keys(skipRulesConfig);
+if (reportSkipRuleNames.length > 0) {
+    addToReport(`Skipped Rules:`);
+    reportSkipRuleNames.forEach(rule => {
+        const paths = skipRulesConfig[rule].paths || [];
+        addToReport(`  - ${rule} → ${paths.length ? paths.join(', ') : '(all files)'}`);
+    });
 }
 addToReport('');
 addToReport('───────────────────────────────────────────────────────────────');

--- a/bin/runLint.js
+++ b/bin/runLint.js
@@ -27,6 +27,22 @@ const adpDevsiteUtilsDir = path.dirname(__dirname);
 // Get the current working directory (target repo where the command is run)
 const targetDir = process.cwd();
 
+// Collect rules to skip from SKIP_* environment variables (e.g. SKIP_NO_HTML_COMMENTS=true → no-html-comments)
+let skipRules = [];
+for (const [key, value] of Object.entries(process.env)) {
+    if (key.startsWith('SKIP_') && value === 'true') {
+        const ruleName = key.slice('SKIP_'.length).toLowerCase().replace(/_/g, '-');
+        skipRules.push(ruleName);
+    }
+}
+
+// Also support --skip-rules CLI flag (comma-separated rule names)
+const skipRulesArgIndex = process.argv.indexOf('--skip-rules');
+if (skipRulesArgIndex !== -1 && process.argv[skipRulesArgIndex + 1]) {
+    const cliRules = process.argv[skipRulesArgIndex + 1].split(',').map(r => r.trim()).filter(Boolean);
+    skipRules.push(...cliRules);
+}
+
 // Read lint configuration from content repo's package.json
 let skipUrlPatterns = [];
 let skipFrontmatterPaths = [];
@@ -36,6 +52,10 @@ if (fs.existsSync(packageJsonPath)) {
         const packageJson = JSON.parse(fs.readFileSync(packageJsonPath, 'utf8'));
         skipUrlPatterns = packageJson?.lint?.skipUrlPatterns || [];
         skipFrontmatterPaths = packageJson?.lint?.skipFrontmatterPaths || [];
+
+        // Merge skipRules from package.json with CLI
+        const packageSkipRules = packageJson?.lint?.skipRules || [];
+        skipRules = [...new Set([...skipRules, ...packageSkipRules])];
 
         if (skipUrlPatterns.length > 0) {
             logStep(`Skipping ${skipUrlPatterns.length} URL pattern(s):`);
@@ -49,6 +69,20 @@ if (fs.existsSync(packageJsonPath)) {
     } catch (error) {
         log(`Failed to parse package.json: ${error.message}`, 'warn');
     }
+}
+
+if (skipRules.length > 0) {
+    logStep(`Skipping ${skipRules.length} rule(s):`);
+    skipRules.forEach(rule => verbose(`  - ${rule}`));
+}
+
+// Check whether a ruleId should be skipped.
+// Matches both short form ("no-html-comments") and namespaced form ("remark-lint:no-html-comments").
+function isRuleSkipped(ruleId) {
+    if (!ruleId || skipRules.length === 0) return false;
+    return skipRules.some(skipRule =>
+        ruleId === skipRule || ruleId === `remark-lint:${skipRule}` || ruleId.endsWith(`:${skipRule}`)
+    );
 }
 
 // Helper function to check if a file should skip frontmatter check
@@ -88,6 +122,9 @@ addToReport('');
 addToReport(`Generated: ${new Date().toISOString()}`);
 addToReport(`Mode: ${lintMode}`);
 addToReport(`Target Directory: ${targetDir}`);
+if (skipRules.length > 0) {
+    addToReport(`Skipped Rules: ${skipRules.join(', ')}`);
+}
 addToReport('');
 addToReport('───────────────────────────────────────────────────────────────');
 
@@ -297,11 +334,14 @@ for (const filePath of markdownFiles) {
         // Process the file with remark (pass path for linters that need filename access)
         const result = await processor.process({ path: filePath, value: content });
 
-        if (result.messages.length > 0) {
-            filesWithIssues++;
-            totalIssues += result.messages.length;
+        // Filter out messages from skipped rules
+        const messages = result.messages.filter(m => !isRuleSkipped(m.ruleId));
 
-            const hasErrors = result.messages.some(m => m.fatal);
+        if (messages.length > 0) {
+            filesWithIssues++;
+            totalIssues += messages.length;
+
+            const hasErrors = messages.some(m => m.fatal);
             if (hasErrors) {
                 log(`\n${relativePath}:`);
             } else {
@@ -314,7 +354,7 @@ for (const filePath of markdownFiles) {
             addToReport('───────────────────────────────────────────────────────────────');
 
             // Display all messages for this file
-            result.messages.forEach(message => {
+            messages.forEach(message => {
                 const severity = message.fatal ? '❌ ERROR' : '⚠️  WARNING';
                 const logFn = message.fatal ? log : verbose;
                 logFn(` ${severity} ${message}`);

--- a/bin/runLint.js
+++ b/bin/runLint.js
@@ -371,11 +371,18 @@ for (const filePath of markdownFiles) {
             }
         }
 
+        // Filter out messages from rules skipped for this file's path
+        for (let i = result.messages.length - 1; i >= 0; i--) {
+            if (isRuleSkipped(result.messages[i].ruleId, filePath)) {
+                result.messages.splice(i, 1);
+            }
+        }
+
         if (result.messages.length > 0) {
             filesWithIssues++;
-            totalIssues += messages.length;
+            totalIssues += result.messages.length;
 
-            const hasErrors = messages.some(m => m.fatal);
+            const hasErrors = result.messages.some(m => m.fatal);
             if (hasErrors) {
                 log(`\n${relativePath}:`);
             } else {
@@ -388,7 +395,7 @@ for (const filePath of markdownFiles) {
             addToReport('───────────────────────────────────────────────────────────────');
 
             // Display all messages for this file
-            messages.forEach(message => {
+            result.messages.forEach(message => {
                 const severity = message.fatal ? '❌ ERROR' : '⚠️  WARNING';
                 const logFn = message.fatal ? log : verbose;
                 logFn(` ${severity} ${message}`);


### PR DESCRIPTION
## Description
Allow Dev to manually disable linter check to avoid false positive noise in lint checking
usage example:
note that path can be a file name or a folder name, if no name is declared, all files will skip the the declared rule
<img width="386" height="170" alt="image" src="https://github.com/user-attachments/assets/455fb4bf-3743-4368-9b67-aa70a57ee520" />



## Related File
https://github.com/AdobeDocs/adp-devsite-github-actions-test/blob/main/package.json

## JIRA 
[DEVSITE-2293](https://jira.corp.adobe.com/browse/DEVSITE-2293)

## After Skip Config - File name as path
<img width="748" height="249" alt="image" src="https://github.com/user-attachments/assets/3d3f053a-b586-43dc-b566-d681d63e6de8" />
<img width="1059" height="185" alt="image" src="https://github.com/user-attachments/assets/9fa72cb5-b54b-47fe-9aaf-8ec95075d423" />

## Before Skip Config


## After Skip Config - Folder name as path (this will skip all files in this path)
<img width="706" height="238" alt="image" src="https://github.com/user-attachments/assets/aebc2f53-30da-47c7-becb-7afa84a741c6" />

<img width="979" height="165" alt="image" src="https://github.com/user-attachments/assets/ca8b81a3-d41f-4a9b-b055-8c064d066db0" />


