### PR TITLE
new linter: detect consecutive dashes in filenames and directory paths

### DIFF
--- a/bin/runLint.js
+++ b/bin/runLint.js
@@ -104,7 +104,7 @@ const remarkLintNoBlockInList = await import(path.join(adpDevsiteUtilsDir, 'lint
 const remarkLintNoUnescapedOpeningCurlyBraces = await import(path.join(adpDevsiteUtilsDir, 'linters', 'remark-lint-no-unescaped-opening-curly-braces.js'))
 const remarkLintNoAltTextForImage = await import(path.join(adpDevsiteUtilsDir, 'linters', 'remark-lint-no-alt-text-for-image.js'))
 const remarkLintBigImage = await import(path.join(adpDevsiteUtilsDir, 'linters', 'remark-lint-big-image.js'))
-const remarkLintNoKebabInFilename = await import(path.join(adpDevsiteUtilsDir, 'linters', 'remark-lint-no-kebab-in-filename.js'))
+const remarkLintNoUnsanitizedPathSegments = await import(path.join(adpDevsiteUtilsDir, 'linters', 'remark-lint-no-unsanitized-path-segments.js'))
 const remarkLintInternalLinkExtension = await import(path.join(adpDevsiteUtilsDir, 'linters', 'remark-lint-internal-link-extension.js'))
 const remarkLintAnchorLinkExtension = await import(path.join(adpDevsiteUtilsDir, 'linters', 'remark-lint-anchor-link-extension.js'))
 const remarkLintNoDetailsHtml = await import(path.join(adpDevsiteUtilsDir, 'linters', 'remark-lint-no-details-html.js'))
@@ -184,7 +184,7 @@ function createProcessor(includeFrontmatterCheck) {
       .use(remarkLintNoBracketInTable.default, ['error'])
       .use(remarkLintNoUnescapedOpeningCurlyBraces.default, ['error'])
       .use(remarkLintNoAltTextForImage.default, ['warning'])
-      .use(remarkLintNoKebabInFilename.default, ['error'])
+      .use(remarkLintNoUnsanitizedPathSegments.default, ['error'])
       .use(remarkLintInternalLinkExtension.default, ['error'])
       .use(remarkLintAnchorLinkExtension.default, ['error'])
       .use(remarkLintNoHorizontalLines.default, ['error']);

--- a/linters/remark-lint-no-kebab-in-filename.js
+++ b/linters/remark-lint-no-kebab-in-filename.js
@@ -1,37 +1,59 @@
+const RULE_ID = 'remark-lint:no-kebab-in-filename'
+
+const POSITION = {
+  start: { line: 1, column: 1 },
+  end: { line: 1, column: 1 }
+}
+
+function report(file, message, severity) {
+  if (severity === 'error') {
+    file.fail(message, POSITION, RULE_ID)
+  } else {
+    file.message(message, POSITION, RULE_ID)
+  }
+}
+
+function validateSegment(segment, label, file, severity) {
+  const validCharsRegex = /^[a-z0-9-]+$/
+  if (!validCharsRegex.test(segment)) {
+    const invalidChars = segment.match(/[^a-z0-9-]/g) || []
+    const unique = [...new Set(invalidChars)]
+    report(file, `${label} "${segment}" contains invalid character(s): ${unique.map(c => `"${c}"`).join(', ')}. Only lowercase letters (a-z), numbers (0-9), and hyphens (-) are allowed.`, severity)
+  }
+
+  if (/--/.test(segment)) {
+    report(file, `${label} "${segment}" contains consecutive dashes (--). EDS normalizes consecutive dashes into a single dash, which will cause deployment failures.`, severity)
+  }
+
+  if (segment.startsWith('-') || segment.endsWith('-')) {
+    report(file, `${label} "${segment}" has a leading or trailing dash. EDS strips leading/trailing dashes, which will cause deployment failures.`, severity)
+  }
+}
+
 const remarkLintNoKebabInFilename = (severity = 'warning') => {
   return (tree, file) => {
-    // Handle both array format [severity] and direct severity string
     const actualSeverity = Array.isArray(severity) ? severity[0] : severity
 
-    // Get the filename from the file path
     const filename = file.basename || (file.path ? file.path.split('/').pop() : null)
 
     if (!filename) {
       return
     }
 
-    // Remove the .md extension for validation
     const filenameWithoutExt = filename.replace(/\.md$/, '')
+    validateSegment(filenameWithoutExt, 'Filename', file, actualSeverity)
 
-    // Only allow lowercase letters, numbers, and hyphens
-    const validFilenameRegex = /^[a-z0-9-]+$/
-
-    if (!validFilenameRegex.test(filenameWithoutExt)) {
-      // Find the invalid characters
-      const invalidChars = filenameWithoutExt.match(/[^a-z0-9-]/g) || []
-      const uniqueInvalidChars = [...new Set(invalidChars)]
-
-      const position = {
-        start: { line: 1, column: 1 },
-        end: { line: 1, column: 1 }
-      }
-
-      const message = `Filename "${filename}" contains invalid character(s): ${uniqueInvalidChars.map(c => `"${c}"`).join(', ')}. Only lowercase letters (a-z), numbers (0-9), and hyphens (-) are allowed.`
-
-      if (actualSeverity === 'error') {
-        file.fail(message, position, 'remark-lint:no-kebab-in-filename')
-      } else {
-        file.message(message, position, 'remark-lint:no-kebab-in-filename')
+    if (file.path) {
+      const srcPagesIndex = file.path.indexOf('src/pages/')
+      if (srcPagesIndex !== -1) {
+        const relativePath = file.path.slice(srcPagesIndex + 'src/pages/'.length)
+        const segments = relativePath.split('/')
+        segments.pop() // remove filename (already checked above)
+        for (const dir of segments) {
+          if (dir) {
+            validateSegment(dir, 'Directory', file, actualSeverity)
+          }
+        }
       }
     }
   }

--- a/linters/remark-lint-no-unsanitized-path-segments.js
+++ b/linters/remark-lint-no-unsanitized-path-segments.js
@@ -1,4 +1,6 @@
-const RULE_ID = 'remark-lint:no-kebab-in-filename'
+import path from 'path'
+
+const RULE_ID = 'remark-lint:no-unsanitized-path-segments'
 
 const POSITION = {
   start: { line: 1, column: 1 },
@@ -30,11 +32,11 @@ function validateSegment(segment, label, file, severity) {
   }
 }
 
-const remarkLintNoKebabInFilename = (severity = 'warning') => {
+const remarkLintNoUnsanitizedPathSegments = (severity = 'warning') => {
   return (tree, file) => {
     const actualSeverity = Array.isArray(severity) ? severity[0] : severity
 
-    const filename = file.basename || (file.path ? file.path.split('/').pop() : null)
+    const filename = file.basename || (file.path ? path.basename(file.path) : null)
 
     if (!filename) {
       return
@@ -44,10 +46,11 @@ const remarkLintNoKebabInFilename = (severity = 'warning') => {
     validateSegment(filenameWithoutExt, 'Filename', file, actualSeverity)
 
     if (file.path) {
-      const srcPagesIndex = file.path.indexOf('src/pages/')
+      const srcPagesMarker = path.join('src', 'pages')
+      const srcPagesIndex = file.path.indexOf(srcPagesMarker)
       if (srcPagesIndex !== -1) {
-        const relativePath = file.path.slice(srcPagesIndex + 'src/pages/'.length)
-        const segments = relativePath.split('/')
+        const relativePath = file.path.slice(srcPagesIndex + srcPagesMarker.length + path.sep.length)
+        const segments = relativePath.split(path.sep)
         segments.pop() // remove filename (already checked above)
         for (const dir of segments) {
           if (dir) {
@@ -59,4 +62,4 @@ const remarkLintNoKebabInFilename = (severity = 'warning') => {
   }
 }
 
-export default remarkLintNoKebabInFilename
+export default remarkLintNoUnsanitizedPathSegments


### PR DESCRIPTION
## JIRA
[DEVSITE-2235](https://jira.corp.adobe.com/browse/DEVSITE-2235)

## Description

The Helix admin API uses sanitizeName from @adobe/helix-shared-string to normalize path segments. Here's the source:
```
export function sanitizeName(name) {
  return name
    .toLowerCase()
    .normalize('NFD')
    .replace(/[\u0300-\u036f]/g, '')
    .replace(/[^a-z0-9]+/g, '-')
    .replace(/^-|-$/g, '');
}
```

The critical regex is .replace(/[^a-z0-9]+/g, '-') — the + quantifier matches one or more consecutive non-alphanumeric characters (including -) and replaces them all with a single -. So foo--bar becomes foo-bar.

When the deploy script sends a preview/publish request for a file with -- in its path, the admin API sanitizes the URL to a path that no longer matches the actual file in the repo, causing the request to fail.

## Test files
https://github.com/AdobeDocs/adp-devsite-github-actions-test/commit/7fea0682f1878f58e066dfc3bc7d43aaee618e4b

## Test Result 
<img width="1058" height="185" alt="image" src="https://github.com/user-attachments/assets/34feb502-c58c-46ce-9639-0efe9b6bf7da" />
<img width="1060" height="185" alt="image" src="https://github.com/user-attachments/assets/79a60c42-1711-49bf-81e2-7171907191f5" />

