### PR TITLE
fix: collapse consecutive dashes in renameFiles

### DIFF
--- a/bin/renameFiles.js
+++ b/bin/renameFiles.js
@@ -41,7 +41,8 @@ try {
 
     function toEdsCase(str) {
         const isValid = Boolean(/^([a-z0-9-]*)$/.test(str));
-        return isValid ? str : toKebabCase(str);
+        const result = isValid ? str : toKebabCase(str);
+        return result.replace(/-{2,}/g, '-');
     }
 
     function toUrl(str) {


### PR DESCRIPTION
Collapse 2+ consecutive dashes into a single dash in `toEdsCase`, matching how EDS sanitizes paths.

Closes #81

Generated with [Claude Code](https://claude.ai/code)