### PR TITLE
fix: detect inline HTML comments in remark-lint-no-html-comments

### DIFF
--- a/linters/remark-lint-no-html-comments.js
+++ b/linters/remark-lint-no-html-comments.js
@@ -1,41 +1,53 @@
-import { visit } from 'unist-util-visit'
-
 const remarkLintNoHtmlComments = (severity = 'warning') => {
   return (tree, file) => {
-    // Handle both array format [severity] and direct severity string
     const actualSeverity = Array.isArray(severity) ? severity[0] : severity
 
-    // Visit all HTML nodes to find HTML comments
-    visit(tree, 'html', (node) => {
-      const content = node.value
+    const content = file.toString()
+    const lines = content.split('\n')
+    let inCodeBlock = false
+    let inFrontmatter = false
 
-      // Check for HTML comments
-      const htmlCommentRegex = /<!--[\s\S]*?-->/g
-      let commentMatch
+    for (let i = 0; i < lines.length; i++) {
+      const lineNumber = i + 1
+      const line = lines[i]
+      const trimmed = line.trim()
 
-      while ((commentMatch = htmlCommentRegex.exec(content)) !== null) {
-        const [fullComment] = commentMatch
+      // Skip YAML frontmatter
+      if (i === 0 && trimmed === '---') {
+        inFrontmatter = true
+        continue
+      }
+      if (inFrontmatter) {
+        if (trimmed === '---') inFrontmatter = false
+        continue
+      }
 
+      // Skip fenced code blocks
+      if (trimmed.startsWith('```') || trimmed.startsWith('~~~')) {
+        inCodeBlock = !inCodeBlock
+        continue
+      }
+      if (inCodeBlock) continue
+
+      // Strip inline code spans to avoid false positives inside backticks
+      const stripped = line.replace(/`[^`]*`/g, (m) => ' '.repeat(m.length))
+
+      const htmlCommentRegex = /<!--.*?-->/g
+      let match
+      while ((match = htmlCommentRegex.exec(stripped)) !== null) {
         const position = {
-          start: {
-            line: node.position.start.line,
-            column: node.position.start.column + commentMatch.index + 1
-          },
-          end: {
-            line: node.position.start.line,
-            column: node.position.start.column + commentMatch.index + fullComment.length
-          }
+          start: { line: lineNumber, column: match.index + 1 },
+          end: { line: lineNumber, column: match.index + match[0].length + 1 }
         }
-
-        const message = 'HTML comments are not allowed. Use markdown comments instead or remove the comment.'
-
+        const message =
+          'HTML comments are not allowed. Use markdown comments instead or remove the comment.'
         if (actualSeverity === 'error') {
           file.fail(message, position, 'remark-lint:no-html-comments')
         } else {
           file.message(message, position, 'remark-lint:no-html-comments')
         }
       }
-    })
+    }
   }
 }
 


### PR DESCRIPTION
## Problem
All linter check passed on [this commit](https://github.com/AdobeDocs/uxp-indesign/commit/0305627482593ad16ff4b43d4d12e61e40aea14a) but the [deployment](https://github.com/AdobeDocs/uxp-indesign/actions/runs/25699743980/attempts/4) failed

/indesign/uxp/resources/recipes/html-elements/index.md ❌ Error HTTP 400 - preview failed

## Solution
Fix false negative in `remark-lint-no-html-comments` where inline HTML comments embedded within paragraph text were not detected, allowing deploys to fail with HTTP 400.

Switch from AST node visiting to raw text scanning so comments like `text <!-- comment --> text` are caught regardless of how remark parses the surrounding content.

## JIRA
[DEVSITE-2401](https://jira.corp.adobe.com/browse/DEVSITE-2401)

## Issue
Closes #84

## Test Code
[github-action-test](https://github.com/AdobeDocs/adp-devsite-github-actions-test/commit/6e86496c9b7d87c24e9d4df7eea0b69d62e136fc)
<img width="842" height="192" alt="image" src="https://github.com/user-attachments/assets/35013500-6989-4dfd-8855-73735e7c168b" />
