### PR TITLE
fix: remove buildContributors from local dev

### DIFF
--- a/bin/dev.js
+++ b/bin/dev.js
@@ -26,18 +26,9 @@ const buildSiteMetadata = () => {
   }
 };
 
-const buildContributors = () => {
-  try {
-    execSync('npm run buildContributors', { cwd: __dirname, stdio: 'inherit' });
-  } catch (error) {
-    console.warn('Failed to build contributors:', error.message);
-  }
-};
-
 const currentBranch = getCurrentBranch();
 const DOCS_DIRECTORY = process.env.DIRECTORY ||  './src/pages';
 
-buildContributors();
 buildSiteMetadata();
 
 const app = express();

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   "author": "",
   "license": "Apache-2.0",
   "engines": {
-    "node": "^24.11.08"
+    "node": "^24.11.0"
   },
   "dependencies": {
     "dotenv": "^17.2.2",


### PR DESCRIPTION
## Description

`buildContributors` is slow and breaks on fork branches. Adding support for that adds complexity without fixing the speed issue, so it's removed from local dev entirely. Users can still opt in by running `npm run buildContributors` explicitly.

Slack: https://adobeio.slack.com/archives/C06M1C7UBV3/p1780585610859179

## Related
https://github.com/AdobeDocs/dev-docs-reference/pull/64

## Ticket
https://jira.corp.adobe.com/browse/DEVSITE-2438

## Before
<img width="672" height="650" alt="Screenshot 2026-06-04 at 12 50 15 PM" src="https://github.com/user-attachments/assets/7f5a0681-c2b1-44af-8aa5-530c289d2478" />

## After
<img width="669" height="371" alt="Screenshot 2026-06-04 at 12 55 19 PM" src="https://github.com/user-attachments/assets/b3548923-8a60-437d-a27c-eff495698c40" />
