### PR TITLE
Devsite 2442 - Additional Args for linter

### DIFF
--- a/bin/runLint.js
+++ b/bin/runLint.js
@@ -275,7 +275,10 @@ function findMarkdownFiles(dir) {
     return files;
 }
 
-const markdownFiles = findMarkdownFiles(srcPagesDir);
+const cliFiles = process.argv.slice(2).filter(a => !a.startsWith('-'));
+const markdownFiles = cliFiles.length > 0
+    ? cliFiles.map(f => path.resolve(targetDir, f))
+    : findMarkdownFiles(srcPagesDir);
 
 if (markdownFiles.length === 0) {
     log('No markdown files found in src/pages', 'warn');

--- a/bin/runLint.js
+++ b/bin/runLint.js
@@ -297,8 +297,8 @@ let hasFatalErrors = false;
 let totalErrors = 0;
 let totalWarnings = 0;
 
-// Pre-check: detect JSON files in src/pages/
-const jsonCheckResult = lintNoJsonInSrcPages.default(srcPagesDir, targetDir);
+// Pre-check: detect JSON files in src/pages/ (only in full-scan mode; scoped runs check changed files only)
+const jsonCheckResult = cliFiles.length === 0 ? lintNoJsonInSrcPages.default(srcPagesDir, targetDir) : { messages: [] };
 if (jsonCheckResult.messages.length > 0) {
     addToReport('───────────────────────────────────────────────────────────────');
     addToReport('📁 JSON FILES IN src/pages/');


### PR DESCRIPTION
The lint-v3.yml will read the changed file list in a Pull Request and append them as args when calling the lint. runLint.js reads these args and run limited version of linter. If no additional args are detected, runLint.js will run the full lint as usual.

Test PR: https://github.com/AdobeDocs/adp-devsite-github-actions-test/pull/150
JIRA: [DEVSITE-2442](https://jira.corp.adobe.com/browse/DEVSITE-2442)
Related Commit on Workflow repo: https://github.com/AdobeDocs/adp-devsite-workflow/pull/42/changes/52dd94cd49d7ba938d7881bbdf708fb239aef1e9 on https://github.com/AdobeDocs/adp-devsite-workflow/pull/42