### PR TITLE
fix: surface dev server startup errors

### DIFF
--- a/bin/dev.js
+++ b/bin/dev.js
@@ -44,4 +44,7 @@ app.use(
 
 app.listen(PORT, () => {
   console.debug(`Docs dev server is running on port ${PORT}`);
+}).on('error', (err) => {
+  console.error(err);
+  process.exit(1);
 });


### PR DESCRIPTION
## Description

Surface dev server startup errors (like port conflicts) instead of failing silently. Same approach as [devsite-runtime-connector](https://github.com/aemsites/devsite-runtime-connector/blob/9fc6e2ef18bdb3b81daed7ec502a5f11343f7a5c/test/dev/server.ts#L30).

## Ticket

https://jira.corp.adobe.com/browse/DEVSITE-2430

## Test

1. Start `npm run dev` in any content repo
2. In a second terminal, run `npm run dev` again
3. Verify the second instance shows: `Error: listen EADDRINUSE: address already in use :::3003`

## Before

Silent failure — no error message when port is in use.

<img width="1728" height="554" alt="content-before" src="https://github.com/user-attachments/assets/bcf8d480-d8f5-4d06-8e30-eb6c36b23abb" />



## After

`Error: listen EADDRINUSE: address already in use :::3003`

<img width="1728" height="1080" alt="content-after" src="https://github.com/user-attachments/assets/65512546-ea18-40b7-bbe2-7adc0a28b34a" />
