### PR TITLE
fix(no-dead-urls): fix bad User-Agent header, suppress redirect noise, tolerate transient blips

### DIFF
--- a/bin/runLint.js
+++ b/bin/runLint.js
@@ -183,8 +183,15 @@ function createProcessor(includeFrontmatterCheck) {
         .use(remarkLintNoDeadUrls, {
           skipUrlPatterns: [...skipUrlPatterns, /^mailto:/, /^#/],
           deadOrAliveOptions: {
-            maxRetries: 0,
-            sleep: 0,
+            // A single transient blip (rate limit, cold CDN edge, brief network
+            // hiccup) would otherwise be reported as a dead link with zero
+            // chance to recover, so allow one retry with a short backoff.
+            maxRetries: 1,
+            sleep: () => 1000,
+            // Under concurrent load (10 URLs checked in parallel per file),
+            // some requests queue long enough to approach the default 3s
+            // timeout even though the target is alive; give them more room.
+            timeout: 10000,
             https: {
               rejectUnauthorized: false, // Don't fail on SSL cert issues
             },
@@ -231,8 +238,17 @@ function createProcessor(includeFrontmatterCheck) {
         .use(remarkLintNoDeadUrls, {
             skipUrlPatterns: [...skipUrlPatterns, /^mailto:/, /^#/],
             deadOrAliveOptions: {
-                maxRetries: 0,
-                sleep: 0,
+                // A single transient blip (rate limit, cold CDN edge, brief
+                // network hiccup) would otherwise be reported as a dead link
+                // with zero chance to recover, so allow one retry with a
+                // short backoff.
+                maxRetries: 1,
+                sleep: () => 1000,
+                // Under concurrent load (10 URLs checked in parallel per
+                // file), some requests queue long enough to approach the
+                // default 3s timeout even though the target is alive; give
+                // them more room.
+                timeout: 10000,
                 https: {
                     rejectUnauthorized: false, // Don't fail on SSL cert issues
                 },
@@ -368,6 +384,17 @@ for (const filePath of markdownFiles) {
         // Filter out messages from rules skipped for this file's path
         for (let i = result.messages.length - 1; i >= 0; i--) {
             if (isRuleSkipped(result.messages[i].ruleId, filePath)) {
+                result.messages.splice(i, 1);
+            }
+        }
+
+        // Suppress "redirecting URL" advisories from no-dead-urls: the URL was
+        // confirmed alive (dead-or-alive followed the redirect successfully),
+        // matching the `followRedirects: true` config below which is meant to
+        // treat redirects as non-issues rather than flag them.
+        for (let i = result.messages.length - 1; i >= 0; i--) {
+            const message = result.messages[i];
+            if (message.ruleId === 'no-dead-urls' && /^Unexpected redirecting URL/.test(message.message)) {
                 result.messages.splice(i, 1);
             }
         }

--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
   },
   "scripts": {
     "start": "node index.js",
-    "list": "node index.js"
+    "list": "node index.js",
+    "postinstall": "patch-package"
   },
   "author": "",
   "license": "Apache-2.0",
@@ -20,6 +21,7 @@
     "dotenv": "^17.2.2",
     "express": "^5.1.0",
     "glob": "^13.0.0",
+    "patch-package": "^8.0.1",
     "remark": "^15.0.1",
     "remark-cli": "^12.0.1",
     "remark-frontmatter": "^5.0.0",

--- a/patches/dead-or-alive+1.0.5.patch
+++ b/patches/dead-or-alive+1.0.5.patch
@@ -1,0 +1,18 @@
+diff --git a/node_modules/dead-or-alive/lib/index.js b/node_modules/dead-or-alive/lib/index.js
+index 38cc6ea..4d9481f 100644
+--- a/node_modules/dead-or-alive/lib/index.js
++++ b/node_modules/dead-or-alive/lib/index.js
+@@ -210,7 +210,12 @@ async function deadOrAliveInternal(state, url) {
+ 
+     response = await fetch(url, {
+       headers: {
+-        userAgent: state.userAgent,
++        // Note: must be the real `user-agent` header name; `userAgent` is not
++        // a valid HTTP header and was silently sent as a bogus extra header,
++        // leaving the real `user-agent` header at undici's default (`undici`),
++        // which trivially identifies the request as non-browser/bot traffic
++        // to any user-agent-based bot mitigation (e.g. Akamai).
++        'user-agent': state.userAgent,
+         // <https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Upgrade-Insecure-Requests>
+         'Upgrade-Insecure-Requests': '1',
+         accept:


### PR DESCRIPTION
## Jira: [DEVSITE-2493](https://jira.corp.adobe.com/browse/DEVSITE-2493)

## Problem

The `no-dead-urls` lint check sometimes flags links as dead (or noisily flags redirecting links) even though they're verifiably alive. This forces content authors to argue that a flagged link "isn't actually dead" — see [AdobeDocs/aep-mobile-sdkdocs#913](https://github.com/AdobeDocs/aep-mobile-sdkdocs/pull/913), which surfaced this.

Root-caused to three separate, compounding issues in how `bin/runLint.js` invokes `remark-lint-no-dead-urls` (which wraps `dead-or-alive`):

1. **Bad User-Agent header key in `dead-or-alive`.** It sends headers as `{ userAgent: state.userAgent, ... }` — `userAgent` (camelCase) isn't a valid HTTP header name, so it's sent as a bogus, ignored header. The real `User-Agent` header the target server sees falls back to undici's default: literally `"undici"`. That trivially identifies the linter's requests as bot/script traffic to any UA-based bot mitigation (e.g. Akamai, which fronts business.adobe.com), causing intermittent false "dead" reports on alive URLs. Verified with a local HTTP echo server: before the fix, the server received `useragent: "Mozilla/5.0 ..."` (bogus, unused) and `user-agent: "undici"` (the real one).

2. **"Redirecting URL" warning fires despite `followRedirects: true`.** `runLint.js` sets `followRedirects: true` with the clear intent that redirecting-but-alive URLs shouldn't be flagged, but `remark-lint-no-dead-urls` unconditionally emits a separate advisory whenever a link permanently redirects, with no option to suppress it. This produced noise on things like Experience League's locale redirect (`/docs/...` → `/en/docs/...`), which effectively every page on that domain does.

3. **Zero retry tolerance + concurrency causes flaky false "dead" results.** `deadOrAliveOptions` had `maxRetries: 0` and the library's default 3s timeout. `remark-lint-no-dead-urls` checks up to 10 URLs concurrently per file. Empirically verified: the same 46 unique external URLs from one real content file pass 44/46 when checked *sequentially* (the only 2 genuine dead links are npmjs.com package pages returning 403, reproducible via plain `curl` too — npm blocking the request, unrelated to this bug), but intermittently report additional false "dead" results at the production concurrency of 10, because some requests queue long enough under load to approach/exceed the 3s timeout, and zero retries meant a single such timeout was reported as a permanent dead link.

## Fix

1. Patch `dead-or-alive` via `patch-package` (`patches/dead-or-alive+1.0.5.patch`) to send the correct `user-agent` header key. Wired `postinstall: patch-package` and moved `patch-package` to `dependencies` (not `devDependencies`) so the patch applies under the production `npx github:AdobeDocs/adp-devsite-utils runLint` invocation, not just local dev installs.
2. Filter out `no-dead-urls` "Unexpected redirecting URL" messages in `bin/runLint.js`, matching the existing `followRedirects: true` intent.
3. Raise `deadOrAliveOptions.maxRetries` from `0` to `1` (1s backoff) and `timeout` from `3000`ms to `10000`ms.

## Verification

Full local lint (`node bin/runLint.js -v`, 332 files) against `AdobeDocs/aep-mobile-sdkdocs`, before/after:

| Metric | Before | After |
|---|---|---|
| Files with issues | 119 | 114 |
| Total warnings | 444 | 428 |
| "Unexpected dead URL" | 340 | 324 |
| "Unexpected redirecting URL" | 0 (module-level, pre-filter) | 0 |

The two originally-reported false positives (`business.adobe.com/products/brand-concierge.html` dead-URL report, and the Experience League `contextdata` redirect-URL report from aep-mobile-sdkdocs#913) no longer appear anywhere in the full-repo report.

## Test plan

- [x] Ran full local lint against `AdobeDocs/aep-mobile-sdkdocs` before and after, compared reports (see table above)
- [x] Verified `patch-package` reapplies automatically on a clean `rm -rf node_modules && npm install`
- [x] Verified corrected header via a local HTTP echo server capturing raw request headers
- [x] Verified the 3 remaining false positives independently (sequential vs. concurrent checks of the same 46 URLs)
