### PR TITLE
fix(no-dead-urls): fix bad User-Agent header without patch-package

### DIFF
--- a/bin/runLint.js
+++ b/bin/runLint.js
@@ -10,8 +10,37 @@ import remarkLintNoDeadUrls from 'remark-lint-no-dead-urls';
 import { fileURLToPath } from 'url';
 import path from 'path';
 import fs from 'node:fs';
+import { setGlobalDispatcher, getGlobalDispatcher } from 'undici';
 
 const { log, verbose, logSection, logStep } = await import('./scriptUtils.js');
+
+// dead-or-alive (as of 1.0.5) sends its user agent under the header key
+// `userAgent` instead of `user-agent`, so the value is silently dropped and
+// the real `user-agent` header falls back to undici's default (`undici`).
+// That trivially identifies our dead-link checks as bot/script traffic to
+// any UA-based bot mitigation (e.g. Akamai, which fronts business.adobe.com),
+// causing intermittent false "dead" reports on alive URLs.
+//
+// dead-or-alive has no public option to pass through a `headers` object, so
+// we can't fix this by configuration alone. Rather than patching dead-or-alive's
+// source in node_modules (which is sensitive to npm's dependency-hoisting
+// decisions and previously broke `npx github:.../runLint` for some installs),
+// we fix the header at the network layer via undici's global dispatcher.
+// This works regardless of where dead-or-alive's own copy of undici lands in
+// node_modules, because undici stores its global dispatcher on a well-known
+// `globalThis` symbol shared by every copy of the package in the process.
+const REAL_USER_AGENT =
+    'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/125.0.0.0 Safari/537.36';
+
+function fixUserAgentInterceptor(dispatch) {
+    return function dispatchWithFixedUserAgent(opts, handler) {
+        const headers = { ...(opts.headers || {}) };
+        headers['user-agent'] = REAL_USER_AGENT;
+        return dispatch({ ...opts, headers }, handler);
+    };
+}
+
+setGlobalDispatcher(getGlobalDispatcher().compose(fixUserAgentInterceptor));
 
 // Report collection for linter-report.txt
 const reportLines = [];
@@ -183,8 +212,15 @@ function createProcessor(includeFrontmatterCheck) {
         .use(remarkLintNoDeadUrls, {
           skipUrlPatterns: [...skipUrlPatterns, /^mailto:/, /^#/],
           deadOrAliveOptions: {
-            maxRetries: 0,
-            sleep: 0,
+            // A single transient blip (rate limit, cold CDN edge, brief network
+            // hiccup) would otherwise be reported as a dead link with zero
+            // chance to recover, so allow one retry with a short backoff.
+            maxRetries: 1,
+            sleep: () => 1000,
+            // Under concurrent load (10 URLs checked in parallel per file),
+            // some requests queue long enough to approach the default 3s
+            // timeout even though the target is alive; give them more room.
+            timeout: 10000,
             https: {
               rejectUnauthorized: false, // Don't fail on SSL cert issues
             },
@@ -231,8 +267,17 @@ function createProcessor(includeFrontmatterCheck) {
         .use(remarkLintNoDeadUrls, {
             skipUrlPatterns: [...skipUrlPatterns, /^mailto:/, /^#/],
             deadOrAliveOptions: {
-                maxRetries: 0,
-                sleep: 0,
+                // A single transient blip (rate limit, cold CDN edge, brief
+                // network hiccup) would otherwise be reported as a dead link
+                // with zero chance to recover, so allow one retry with a
+                // short backoff.
+                maxRetries: 1,
+                sleep: () => 1000,
+                // Under concurrent load (10 URLs checked in parallel per
+                // file), some requests queue long enough to approach the
+                // default 3s timeout even though the target is alive; give
+                // them more room.
+                timeout: 10000,
                 https: {
                     rejectUnauthorized: false, // Don't fail on SSL cert issues
                 },
@@ -335,6 +380,17 @@ for (const filePath of markdownFiles) {
 
         // Process the file with remark (pass path for linters that need filename access)
         const result = await processor.process({ path: filePath, value: content });
+
+        // Suppress "redirecting URL" advisories from no-dead-urls: the URL was
+        // confirmed alive (dead-or-alive followed the redirect successfully),
+        // matching the `followRedirects: true` config above which is meant to
+        // treat redirects as non-issues rather than flag them.
+        for (let i = result.messages.length - 1; i >= 0; i--) {
+            const message = result.messages[i];
+            if (message.ruleId === 'no-dead-urls' && /^Unexpected redirecting URL/.test(message.message)) {
+                result.messages.splice(i, 1);
+            }
+        }
 
         // Suppress false positive missing-file warnings for files that exist
         // in the repo but outside src/pages/ 

--- a/package.json
+++ b/package.json
@@ -28,7 +28,8 @@
     "remark-lint-no-dead-urls": "^2.0.1",
     "remark-lint-no-hidden-table-cell": "^1.0.1",
     "remark-lint-no-multiple-toplevel-headings": "^4.0.1",
-    "remark-validate-links": "^13.1.0"
+    "remark-validate-links": "^13.1.0",
+    "undici": "^8.0.0"
   },
   "overrides": {
     "glob": "^13.0.0"


### PR DESCRIPTION
## Context

#94 fixed a real bug (dead-or-alive sends `userAgent` instead of `user-agent`, causing Akamai and similar bot-mitigation to see `undici` as the UA and intermittently flag alive links as dead). It shipped via `patch-package` patching `node_modules/dead-or-alive` directly, with a new `postinstall: patch-package` script.

That broke `npx --yes github:AdobeDocs/adp-devsite-utils runLint -v` for [AdobeDocs/VIPMP#260](https://github.com/AdobeDocs/VIPMP/pull/260): the Lint step exited 1 before printing a single line of runLint's own output (no "SECTION: TEST LINT", nothing) — it died during install/startup, not during actual linting. #94 was reverted in #95 to unblock VIPMP, and reverting fixed it (confirmed by rerunning the same VIPMP job right after the revert merged).

Leading hypothesis (h/t David Sima in Slack): this repo has no committed lockfile (`package-lock.json` is gitignored) and is consumed via `npx github:...`, which per npm's docs ignores a dependency's own lockfile anyway — so the resolved dependency tree isn't pinned, and `patch-package`'s hardcoded target path (`node_modules/dead-or-alive`) is sensitive to whatever hoisting decision npm makes for that install. A postinstall failure there can take down the whole `npx` invocation.

## What this PR does instead

Same fix, no patch-package:

- Fixes the User-Agent header at the network layer using undici's global dispatcher (`getGlobalDispatcher().compose(interceptor)` in `bin/runLint.js`), forcing a correct `user-agent` on every outgoing request. This works regardless of where any copy of `undici` ends up in `node_modules`, because undici stores its global dispatcher on a `globalThis` symbol (`Symbol.for('undici.globalDispatcher.2')`) shared by every copy of the package in the process — verified locally with two separate `undici` installs.
- No `postinstall`, no patched files in `node_modules`, no hoisting-sensitive assumptions. `patch-package` is not reintroduced.
- Carries over the other two (unrelated, uncontroversial) fixes from #94, unchanged: suppressing "Unexpected redirecting URL" advisories, and raising `deadOrAliveOptions.maxRetries`/`timeout` to tolerate transient blips.

